### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -1,7 +1,6 @@
 use crate::RustyCable;
 use futures_util::StreamExt as _;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -15,14 +14,12 @@ impl redis::FromRedisValue for RedisMessage {
         match *v {
             redis::Value::Data(ref value) => match serde_json::from_slice(value) {
                 Ok(v) => Ok(v),
-                Err(_) => {
-                    Err(((redis::ErrorKind::TypeError, "Unable to parse given value")).into())
-                }
+                Err(_) => Err((redis::ErrorKind::TypeError, "Unable to parse given value").into()),
             },
-            _ => Err(((
+            _ => Err((
                 redis::ErrorKind::ResponseError,
                 "Incorrect data received from Redis",
-            ))
+            )
                 .into()),
         }
     }

--- a/src/rpc_controller.rs
+++ b/src/rpc_controller.rs
@@ -45,7 +45,7 @@ impl RpcController {
             command,
             identifier,
             connection_identifiers,
-            data: data,
+            data,
         };
 
         let response = client.command(message).await?;

--- a/src/rustycable.rs
+++ b/src/rustycable.rs
@@ -18,7 +18,7 @@ impl RustyCable {
 
         Ok(RustyCable {
             controller,
-            hub: Hub::new(),
+            hub: Hub::create_hub_and_get_sender(),
         })
     }
 
@@ -35,7 +35,7 @@ impl RustyCable {
         session: Arc<Session>,
         stream: String,
         identifier: String,
-    ) -> Result<(), Box<std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         self.hub.send(HubAction::Subscribe {
             session_id: session.uid.clone(),
             stream,

--- a/src/server.rs
+++ b/src/server.rs
@@ -44,7 +44,7 @@ async fn accept_connection(peer: SocketAddr, stream: TcpStream, app: Arc<RustyCa
 
 /// Makes a handshake with the WebSocket request, then creates a session
 async fn handle_connection(
-    peer: SocketAddr,
+    _peer: SocketAddr,
     stream: TcpStream,
     app: Arc<RustyCable>,
 ) -> TungsteniteResult<()> {
@@ -66,14 +66,14 @@ async fn handle_connection(
                     );
                 });
 
-            let (mut parts, body) = response.into_parts();
+            let (mut parts, _) = response.into_parts();
 
             parts.headers.insert(
                 "Sec-Websocket-Protocol",
                 HeaderValue::from_str("actioncable-v1-json").unwrap(),
             );
 
-            let response_with_protocol = Response::from_parts(parts, body);
+            let response_with_protocol = Response::from_parts(parts, ());
 
             Ok(response_with_protocol)
         },
@@ -83,8 +83,8 @@ async fn handle_connection(
 
     let session = Session::new(app.clone(), headers, uri, ws_stream).await;
 
-    if session.is_some() {
-        let session = Arc::new(session.unwrap());
+    if let Some(inner_session) = session {
+        let session = Arc::new(inner_session);
 
         app.add_session(session.clone());
 


### PR DESCRIPTION
Currently avoided fixing `clippy::unit_arg`, as they require some more thorough code changes